### PR TITLE
Prevent npm warning "engine ... wanted"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
 
   "engines": {
-    "node": "0.6"
+    "node": ">=0.6"
   },
 
   "dependencies": {


### PR DESCRIPTION
Instead of requiring 0.6, it should simply work with all versions that are higher than 0.6.
